### PR TITLE
Add menu-bar switch feedback animation and tabbed settings

### DIFF
--- a/App/Info.plist
+++ b/App/Info.plist
@@ -9,8 +9,8 @@
     <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
     <key>CFBundleName</key><string>FanBar</string>
     <key>CFBundlePackageType</key><string>APPL</string>
-    <key>CFBundleShortVersionString</key><string>0.4.1</string>
-    <key>CFBundleVersion</key><string>6</string>
+    <key>CFBundleShortVersionString</key><string>0.4.2</string>
+    <key>CFBundleVersion</key><string>7</string>
     <key>LSMinimumSystemVersion</key><string>11.0</string>
     <key>LSUIElement</key><true/>
 </dict>

--- a/Sources/FanBar/FanBarApp.swift
+++ b/Sources/FanBar/FanBarApp.swift
@@ -1,3 +1,4 @@
+import AppKit
 import FanBarShared
 import SwiftUI
 
@@ -36,11 +37,56 @@ struct FanBarApp: App {
         if CommandLine.arguments.contains("--settings-window-smoke-test") {
             Self.runSettingsWindowSmokeTest(controller: controller)
         }
+        if CommandLine.arguments.contains("--settings-render-test") {
+            Self.runSettingsRenderTest(controller: controller)
+        }
     }
 
     var body: some Scene {
         Settings {
             EmptyView()
+        }
+    }
+
+    /// Renders the settings view to PNG files (light and dark) so layout
+    /// changes can be verified without screen-recording permission. Schedules
+    /// the capture and lets the app finish launching normally — parking the
+    /// main thread in dispatchMain() would drain the main queue on a worker
+    /// thread, where AppKit window work crashes.
+    private static func runSettingsRenderTest(controller: FanController) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            let window = SettingsWindowPresenter.shared.show(controller: controller)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                guard let contentView = window.contentView else {
+                    print("settings-render-test=no-content-view")
+                    exit(EXIT_FAILURE)
+                }
+                let appearances: [(String, NSAppearance?)] = [
+                    ("light", NSAppearance(named: .aqua)),
+                    ("dark", NSAppearance(named: .darkAqua))
+                ]
+                for (name, appearance) in appearances {
+                    window.appearance = appearance
+                    contentView.layoutSubtreeIfNeeded()
+                    guard let bitmap = contentView.bitmapImageRepForCachingDisplay(
+                        in: contentView.bounds
+                    ) else { continue }
+                    contentView.cacheDisplay(in: contentView.bounds, to: bitmap)
+                    guard let data = bitmap.representation(using: .png, properties: [:])
+                    else { continue }
+                    do {
+                        try data.write(
+                            to: URL(fileURLWithPath: "/tmp/fanbar-settings-\(name).png")
+                        )
+                        print("settings-render-\(name)=\(data.count) bytes")
+                    } catch {
+                        print("settings-render-\(name)-error=\(error.localizedDescription)")
+                    }
+                }
+                print("settings-render-test=done")
+                SettingsWindowPresenter.shared.close()
+                exit(EXIT_SUCCESS)
+            }
         }
     }
 

--- a/Sources/FanBar/FanBarSettingsView.swift
+++ b/Sources/FanBar/FanBarSettingsView.swift
@@ -2,6 +2,35 @@ import AppKit
 import FanBarShared
 import SwiftUI
 
+/// Settings panes. The selection persists so the window reopens where the
+/// user left off. Tabs are presented by the window toolbar (the macOS
+/// settings convention); the view only swaps content.
+enum SettingsTab: String, CaseIterable, Identifiable {
+    case menuBar
+    case cooling
+    case general
+
+    static let preferenceKey = "fanbar.settingsSelectedTab"
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .menuBar: fanBarText("菜单栏", "Menu Bar")
+        case .cooling: fanBarText("散热", "Cooling")
+        case .general: fanBarText("通用", "General")
+        }
+    }
+
+    var symbol: String {
+        switch self {
+        case .menuBar: "macwindow"
+        case .cooling: "fan"
+        case .general: "gearshape"
+        }
+    }
+}
+
 struct FanBarSettingsView: View {
     @ObservedObject var controller: FanController
     @AppStorage(MenuBarDisplayMode.preferenceKey)
@@ -10,6 +39,10 @@ struct FanBarSettingsView: View {
     private var visibleCoolingPresetsRawValue = CoolingPresetPreferences.defaultRawValue
     @AppStorage(FanBarLanguage.preferenceKey)
     private var languageRawValue = FanBarLanguage.defaultValue
+    @AppStorage(SwitchFeedbackPreferences.preferenceKey)
+    private var switchFeedbackAnimationEnabled = true
+    @AppStorage(SettingsTab.preferenceKey)
+    private var selectedTabRawValue = SettingsTab.menuBar.rawValue
 
     private var displayMode: MenuBarDisplayMode {
         MenuBarDisplayMode(rawValue: displayModeRawValue) ?? .defaultMode
@@ -19,19 +52,66 @@ struct FanBarSettingsView: View {
         CoolingPresetPreferences.presets(from: visibleCoolingPresetsRawValue)
     }
 
+    private var currentTab: SettingsTab {
+        SettingsTab(rawValue: selectedTabRawValue) ?? .menuBar
+    }
+
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            header
-            Divider()
+        Group {
+            switch currentTab {
+            case .menuBar: menuBarTab
+            case .cooling: coolingTab
+            case .general: generalTab
+            }
+        }
+        .frame(width: 460)
+    }
 
-            VStack(alignment: .leading, spacing: 12) {
-                Text(fanBarText("菜单栏显示", "Menu bar display"))
-                    .font(.headline)
+    // MARK: - Tabs
 
+    private var menuBarTab: some View {
+        menuBarSection
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .padding(.bottom, 16)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var coolingTab: some View {
+        coolingPresetSection
+            .padding(.horizontal, 20)
+            .padding(.top, 12)
+            .padding(.bottom, 16)
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    private var generalTab: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            generalSection
+
+            freeSoftwareNotice
+                .frame(maxWidth: .infinity)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 12)
+        .padding(.bottom, 16)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+    }
+
+    // MARK: - Sections
+
+    private var menuBarSection: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            settingsCard {
                 preview
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 10)
+
+                rowDivider
 
                 Picker(
-                    fanBarText("显示内容", "Display content"),
+                    "",
                     selection: Binding(
                         get: { displayMode },
                         set: { displayModeRawValue = $0.rawValue }
@@ -41,141 +121,213 @@ struct FanBarSettingsView: View {
                         Text(mode.title).tag(mode)
                     }
                 }
+                .labelsHidden()
                 .pickerStyle(.radioGroup)
                 // AppKit caches radio-group item titles; rebuild the group when the language changes.
                 .id(languageRawValue)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
 
-                Text(displayMode.detail)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                rowDivider
+
+                Toggle(isOn: $switchFeedbackAnimationEnabled) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(fanBarText("风扇运转动画", "Fan activity animation"))
+                        Text(fanBarText(
+                            "风扇运转时图标持续旋转并跟随实际转速，停转后缓缓静止。",
+                            "The icon spins with the fans, matching their speed, and coasts to a stop when they halt."
+                        ))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .toggleStyle(.switch)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
             }
 
-            Divider()
-            coolingPresetSettings
-
-            Divider()
-            thermalNotificationSettings
-
-            Divider()
-            languageSettings
-
-            Divider()
-            freeSoftwareNotice
+            sectionFooter(displayMode.detail)
         }
-        .padding(22)
-        .frame(width: 420)
     }
 
-    private var coolingPresetSettings: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack {
-                Text(fanBarText("散热预设", "Cooling presets"))
-                    .font(.headline)
-                Spacer()
-                Text("\(visibleCoolingPresets.count) / 2")
+    private var coolingPresetSection: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            sectionHeader(
+                fanBarText("散热预设", "Cooling presets"),
+                trailing: "\(visibleCoolingPresets.count) / 2"
+            )
+
+            settingsCard {
+                ForEach(Array(FanCoolingPreset.allCases.enumerated()), id: \.element.id) { index, preset in
+                    if index > 0 { rowDivider }
+
+                    HStack(spacing: 9) {
+                        Toggle(
+                            isOn: presetSelectionBinding(for: preset)
+                        ) {
+                            Label(preset.title, systemImage: preset.systemImage)
+                        }
+                        .toggleStyle(.checkbox)
+                        .disabled(
+                            !visibleCoolingPresets.contains(preset)
+                                && visibleCoolingPresets.count >= 2
+                        )
+
+                        Spacer()
+
+                        Text(preset.percentageText)
+                            .font(.system(size: 11, design: .monospaced))
+                            .foregroundColor(.secondary)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                }
+            }
+
+            sectionFooter(fanBarText(
+                "最多选择两个显示在主面板中，百分比为该预设的最大转速。",
+                "Choose up to two presets for the main panel. The percentage is each preset's maximum RPM."
+            ))
+        }
+    }
+
+    private var generalSection: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            settingsCard {
+                Toggle(
+                    isOn: Binding(
+                        get: { controller.highTemperatureNotificationsEnabled },
+                        set: { controller.setHighTemperatureNotificationsEnabled($0) }
+                    )
+                ) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(fanBarFormat(
+                            "CPU 或 GPU 达到 %.0f°C 时通知",
+                            "Notify when CPU or GPU reaches %.0f°C",
+                            ThermalAlertSettings.thresholdCelsius
+                        ))
+                        Text(fanBarText(
+                            "同一次高温只通知一次，降温后再次升高会重新通知。",
+                            "One notification per high-temperature episode; it resets after cooling down."
+                        ))
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .toggleStyle(.switch)
+                .disabled(controller.isRequestingHighTemperatureNotificationPermission)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+
+                rowDivider
+
+                HStack {
+                    Text(fanBarText("语言", "Language"))
+
+                    Spacer(minLength: 12)
+
+                    Picker(
+                        "",
+                        selection: Binding(
+                            get: { languageRawValue },
+                            set: {
+                                languageRawValue = $0
+                                SettingsWindowPresenter.shared.updateTitle()
+                            }
+                        )
+                    ) {
+                        ForEach(FanBarLanguage.allCases) { language in
+                            Text(language.title).tag(language.rawValue)
+                        }
+                    }
+                    .labelsHidden()
+                    .fixedSize()
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+            }
+        }
+    }
+
+    // MARK: - Building blocks
+
+    /// Section title floating above its card, following the macOS grouped
+    /// settings convention.
+    private func sectionHeader(_ title: String, trailing: String? = nil) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title)
+                .font(.system(size: 13, weight: .semibold))
+            Spacer()
+            if let trailing {
+                Text(trailing)
                     .font(.system(size: 11, design: .monospaced))
                     .foregroundColor(.secondary)
             }
+        }
+        .padding(.horizontal, 4)
+    }
 
-            Text(fanBarText(
-                "选择最多两个显示在主面板中。转速按每枚风扇的最大值分别计算。",
-                "Choose up to two presets to show on the main panel. Each fan uses its own maximum RPM."
-            ))
-                .font(.caption)
-                .foregroundColor(.secondary)
+    /// Explanatory text belongs below the card, not between the controls.
+    private func sectionFooter(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11))
+            .foregroundColor(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.horizontal, 4)
+    }
 
-            ForEach(FanCoolingPreset.allCases) { preset in
-                HStack(spacing: 9) {
-                    Toggle(
-                        isOn: presetSelectionBinding(for: preset)
-                    ) {
-                        Label(preset.title, systemImage: preset.systemImage)
-                    }
-                    .toggleStyle(.checkbox)
-                    .disabled(
-                        !visibleCoolingPresets.contains(preset)
-                            && visibleCoolingPresets.count >= 2
-                    )
+    private func settingsCard<Content: View>(
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) { content() }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(cardBackground)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+            )
+    }
 
-                    Spacer()
-
-                    Text(fanBarFormat(
-                        "最大转速 %@",
-                        "Maximum RPM %@",
-                        preset.percentageText
-                    ))
-                        .font(.system(size: 11, design: .monospaced))
-                        .foregroundColor(.secondary)
-                }
-            }
+    /// Color(nsColor:) requires macOS 12; on 11 a primary-tinted fill reads
+    /// as an inset panel in light mode and a raised group in dark mode.
+    @ViewBuilder
+    private var cardBackground: some View {
+        if #available(macOS 12.0, *) {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        } else {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(Color.primary.opacity(0.05))
         }
     }
 
-    private var languageSettings: some View {
-        HStack(alignment: .top, spacing: 12) {
-            VStack(alignment: .leading, spacing: 3) {
-                Text(fanBarText("语言", "Language"))
-                    .font(.headline)
-                Text(fanBarText(
-                    "切换 FanBar 的界面语言，修改会立即生效。",
-                    "Change FanBar's interface language. The change takes effect immediately."
-                ))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
-            }
-
-            Spacer(minLength: 12)
-
-            Picker(
-                "",
-                selection: Binding(
-                    get: { languageRawValue },
-                    set: {
-                        languageRawValue = $0
-                        SettingsWindowPresenter.shared.updateTitle()
-                    }
-                )
-            ) {
-                ForEach(FanBarLanguage.allCases) { language in
-                    Text(language.title).tag(language.rawValue)
-                }
-            }
-            .labelsHidden()
-            .frame(width: 130)
-        }
+    private var rowDivider: some View {
+        Divider().padding(.leading, 12)
     }
 
-    private var thermalNotificationSettings: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text(fanBarText("高温通知", "High-temperature notifications"))
-                .font(.headline)
+    // MARK: - Pieces carried over
 
-            Toggle(
-                isOn: Binding(
-                    get: { controller.highTemperatureNotificationsEnabled },
-                    set: { controller.setHighTemperatureNotificationsEnabled($0) }
-                )
-            ) {
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(fanBarFormat(
-                        "CPU 或 GPU 达到 %.0f°C 时通知",
-                        "Notify when CPU or GPU reaches %.0f°C",
-                        ThermalAlertSettings.thresholdCelsius
-                    ))
-                    Text(fanBarText(
-                        "同一次高温只通知一次，降温后再次升高会重新通知。首次开启需要允许 FanBar 发送通知。",
-                        "One notification per high-temperature episode. A new notification is sent after cooling down and heating up again. Permission is required the first time you enable it."
-                    ))
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+    private func presetSelectionBinding(for preset: FanCoolingPreset) -> Binding<Bool> {
+        Binding(
+            get: { visibleCoolingPresets.contains(preset) },
+            set: { isSelected in
+                var selection = Set(visibleCoolingPresets)
+                if isSelected {
+                    guard selection.count < 2 else { return }
+                    selection.insert(preset)
+                } else {
+                    selection.remove(preset)
                 }
+                visibleCoolingPresetsRawValue = CoolingPresetPreferences.rawValue(for: selection)
             }
-            .toggleStyle(.switch)
-            .disabled(controller.isRequestingHighTemperatureNotificationPermission)
-        }
+        )
     }
 
     /// Clarifies the app's pricing model without competing with settings content.
@@ -197,40 +349,6 @@ struct FanBarSettingsView: View {
         .foregroundColor(.secondary)
     }
 
-    private func presetSelectionBinding(for preset: FanCoolingPreset) -> Binding<Bool> {
-        Binding(
-            get: { visibleCoolingPresets.contains(preset) },
-            set: { isSelected in
-                var selection = Set(visibleCoolingPresets)
-                if isSelected {
-                    guard selection.count < 2 else { return }
-                    selection.insert(preset)
-                } else {
-                    selection.remove(preset)
-                }
-                visibleCoolingPresetsRawValue = CoolingPresetPreferences.rawValue(for: selection)
-            }
-        )
-    }
-
-    private var header: some View {
-        HStack(spacing: 12) {
-            Image(nsImage: NSApplication.shared.applicationIconImage)
-                .resizable()
-                .interpolation(.high)
-                .frame(width: 42, height: 42)
-                .accessibilityHidden(true)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(fanBarText("FanBar 设置", "FanBar Settings"))
-                    .font(.title3.weight(.semibold))
-                Text(fanBarText("自定义菜单栏中的实时信息", "Customize the live menu-bar information"))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
-        }
-    }
-
     private var preview: some View {
         HStack {
             Text(fanBarText("预览", "Preview"))
@@ -244,6 +362,5 @@ struct FanBarSettingsView: View {
                 .padding(.vertical, 6)
                 .background(Capsule().fill(Color.primary.opacity(0.06)))
         }
-        .padding(.vertical, 3)
     }
 }

--- a/Sources/FanBar/FanController.swift
+++ b/Sources/FanBar/FanController.swift
@@ -30,6 +30,13 @@ final class FanController: ObservableObject {
         case preset(FanCoolingPreset)
     }
 
+    /// Drives the menu-bar icon animation for user-visible mode switches.
+    /// Silent re-applies (e.g. after wake) never emit these signals.
+    enum SwitchFeedbackSignal: Equatable {
+        case began
+        case ended(successfully: Bool)
+    }
+
     enum HelperState: Equatable {
         case enabled
         case requiresApproval
@@ -61,6 +68,7 @@ final class FanController: ObservableObject {
     @Published private(set) var curveOutputFraction: Float?
     @Published private(set) var highTemperatureNotificationsEnabled: Bool
     @Published private(set) var isRequestingHighTemperatureNotificationPermission = false
+    @Published private(set) var switchFeedback: SwitchFeedbackSignal?
 
     private var localClient: SMCClient?
     private let helperClient = HelperClient()
@@ -225,6 +233,7 @@ final class FanController: ObservableObject {
             return
         }
         isBusy = true
+        if resetsAutomaticRestore { switchFeedback = .began }
         message = fanBarFormat("正在切换到 %d RPM…", "Switching to %d RPM…", rpm)
         Task {
             do {
@@ -239,8 +248,10 @@ final class FanController: ObservableObject {
                 if let readings = try? await helperClient.fans() {
                     fans = readings
                 }
+                if resetsAutomaticRestore { switchFeedback = .ended(successfully: true) }
             } catch {
                 message = fanBarFormat("控制失败：%@", "Control failed: %@", error.localizedDescription)
+                if resetsAutomaticRestore { switchFeedback = .ended(successfully: false) }
             }
             isBusy = false
         }
@@ -259,6 +270,7 @@ final class FanController: ObservableObject {
             return
         }
         isBusy = true
+        if resetsAutomaticRestore { switchFeedback = .began }
         message = fanBarFormat(
             "正在切换到%@模式…",
             "Switching to %@ mode…",
@@ -282,8 +294,10 @@ final class FanController: ObservableObject {
                 if let readings = try? await helperClient.fans() {
                     fans = readings
                 }
+                if resetsAutomaticRestore { switchFeedback = .ended(successfully: true) }
             } catch {
                 message = fanBarFormat("控制失败：%@", "Control failed: %@", error.localizedDescription)
+                if resetsAutomaticRestore { switchFeedback = .ended(successfully: false) }
             }
             isBusy = false
         }
@@ -363,6 +377,7 @@ final class FanController: ObservableObject {
 
         let fraction = temperatureCurve.fraction(at: temperature)
         isBusy = true
+        switchFeedback = .began
         message = fanBarText("正在开启智能温控…", "Enabling smart cooling…")
         Task {
             do {
@@ -376,6 +391,7 @@ final class FanController: ObservableObject {
                 if let readings = try? await helperClient.fans() {
                     fans = readings
                 }
+                switchFeedback = .ended(successfully: true)
             } catch {
                 clearTemperatureCurveState()
                 message = fanBarFormat(
@@ -383,6 +399,7 @@ final class FanController: ObservableObject {
                     "Unable to enable smart cooling: %@",
                     error.localizedDescription
                 )
+                switchFeedback = .ended(successfully: false)
             }
             isBusy = false
         }
@@ -526,6 +543,7 @@ final class FanController: ObservableObject {
             return
         }
         isBusy = true
+        switchFeedback = .began
         message = fanBarText("正在恢复系统控制…", "Restoring system control…")
         Task {
             do {
@@ -540,8 +558,10 @@ final class FanController: ObservableObject {
                 if let readings = try? await helperClient.fans() {
                     fans = readings
                 }
+                switchFeedback = .ended(successfully: true)
             } catch {
                 message = fanBarFormat("恢复失败：%@", "Restore failed: %@", error.localizedDescription)
+                switchFeedback = .ended(successfully: false)
                 if triggeredByTimer {
                     scheduleAutomaticRestoreRetry(after: 5)
                 }

--- a/Sources/FanBar/LegacyStatusItemController.swift
+++ b/Sources/FanBar/LegacyStatusItemController.swift
@@ -11,7 +11,9 @@ final class LegacyStatusItemController: NSObject {
     private var popover: NSPopover?
     private weak var controller: FanController?
     private var observation: AnyCancellable?
+    private var feedbackObservation: AnyCancellable?
     private var defaultsObservation: NSObjectProtocol?
+    private let iconAnimator = MenuBarIconAnimator()
 
     func install(controller: FanController) {
         guard statusItem == nil else { return }
@@ -43,14 +45,36 @@ final class LegacyStatusItemController: NSObject {
         observation = controller.objectWillChange.sink { [weak self] _ in
             DispatchQueue.main.async { self?.updateButton() }
         }
+        iconAnimator.onFinish = { [weak self] in self?.updateButton() }
+        feedbackObservation = controller.$switchFeedback
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] signal in
+                self?.handleSwitchFeedback(signal)
+            }
         defaultsObservation = NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in self?.updateButton() }
+            Task { @MainActor in
+                // Disabling the preference mid-animation restores the still icon.
+                if !SwitchFeedbackPreferences.isEnabled {
+                    self?.iconAnimator.stop()
+                }
+                self?.updateButton()
+            }
         }
         updateButton()
+    }
+
+    private func handleSwitchFeedback(_ signal: FanController.SwitchFeedbackSignal?) {
+        guard let signal, statusItem?.button != nil else { return }
+        guard SwitchFeedbackPreferences.isEnabled else { return }
+        // The icon already follows the live RPM, so only a failed switch
+        // needs an extra cue.
+        if case .ended(successfully: false) = signal {
+            iconAnimator.flashFailure()
+        }
     }
 
     @objc private func togglePopover(_ sender: Any?) {
@@ -88,14 +112,22 @@ final class LegacyStatusItemController: NSObject {
             text = "\(temperature) · \(averageFanSpeed(for: controller))"
         }
 
-        let statusImage = NSImage(
-            systemSymbolName: controller.statusIcon,
-            accessibilityDescription: "FanBar"
-        ) ?? NSApplication.shared.applicationIconImage
-            ?? NSImage(size: NSSize(width: 14, height: 14))
-        statusImage.isTemplate = true
-        statusImage.size = NSSize(width: 12, height: 12)
-        button.image = statusImage
+        // Drive the icon with the live fan reading: it spins while the fans
+        // run and coasts to a stop when they halt. While any animation is
+        // active the animator owns button.image, so the two-second refresh
+        // must not clobber the rotating frames.
+        if SwitchFeedbackPreferences.isEnabled {
+            iconAnimator.update(
+                rpm: averageFanRPM(for: controller),
+                on: button,
+                symbolName: controller.statusIcon
+            )
+        } else {
+            iconAnimator.stop()
+        }
+        if !iconAnimator.isAnimating {
+            button.image = MenuBarIconAnimator.staticIcon(symbol: controller.statusIcon)
+        }
         button.title = text ?? ""
         button.imagePosition = text == nil ? .imageOnly : .imageLeading
         button.imageScaling = .scaleProportionallyDown
@@ -131,6 +163,12 @@ final class LegacyStatusItemController: NSObject {
         case .temperatureAndFanSpeed:
             120
         }
+    }
+
+    private func averageFanRPM(for controller: FanController) -> Double {
+        guard !controller.fans.isEmpty else { return 0 }
+        let total = controller.fans.map(\.currentRPM).reduce(0, +)
+        return Double(total) / Double(controller.fans.count)
     }
 
     private func averageFanSpeed(for controller: FanController) -> String {

--- a/Sources/FanBar/MenuBarIconAnimator.swift
+++ b/Sources/FanBar/MenuBarIconAnimator.swift
@@ -1,0 +1,214 @@
+import AppKit
+
+/// Keeps the status-item icon rotating while the physical fans are running.
+///
+/// The controller refreshes fan readings every two seconds and calls
+/// `update(rpm:on:symbolName:)` with the average RPM; the animator spins at a
+/// perceptual speed mapped from that reading and coasts to a stop once the
+/// fans halt. A failed mode switch can still flash the icon via
+/// `flashFailure()`.
+///
+/// The status item is pure AppKit (macOS 11 target), so SF Symbol effects are
+/// unavailable; rotation is produced by pre-rendering quantized frames of the
+/// template symbol. The timer only runs while an animation is active.
+@MainActor
+final class MenuBarIconAnimator {
+    private enum Phase {
+        case idle
+        case spinning
+        case coasting
+        case blinking
+    }
+
+    /// Called whenever the animation fully stops so the owner can restore the
+    /// authoritative icon for the current mode.
+    var onFinish: (() -> Void)?
+
+    private weak var button: NSButton?
+    private var timer: Timer?
+    private var phase: Phase = .idle
+    private var symbolName = "fan"
+    private var angle = 0.0
+    private var angularVelocity = 0.0
+    private var targetVelocity = 0.0
+    private var lastTick = Date()
+    private var blinkAccumulator = 0.0
+    private var blinkRemaining = 0
+    private var frameCache: [String: NSImage] = [:]
+
+    private let frameQuantum = 15.0           // 24 cached frames per full turn
+    private let blinkInterval = 0.12
+    /// Degrees per second squared used when the fans stop, so the icon slows
+    /// down like a rotor spinning down instead of freezing in place.
+    private let spinDownDeceleration = 260.0
+    /// Readings arrive every two seconds; smoothing avoids velocity jumps.
+    private let velocitySmoothing = 4.0
+
+    var isAnimating: Bool {
+        phase != .idle
+    }
+
+    private var reduceMotion: Bool {
+        NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    }
+
+    /// Follows the live fan reading: spins while fans run, coasts to a stop
+    /// when they halt. Called on every controller refresh.
+    func update(rpm: Double, on button: NSButton, symbolName: String) {
+        self.button = button
+        if self.symbolName != symbolName {
+            self.symbolName = symbolName
+            frameCache.removeAll()
+        }
+
+        guard !reduceMotion else {
+            if phase != .idle { stop() }
+            return
+        }
+
+        let target = Self.perceptualVelocity(forRPM: rpm)
+        switch phase {
+        case .idle:
+            guard target > 0 else { return }
+            targetVelocity = target
+            angularVelocity = target * 0.35 // gentle spin-up from rest
+            phase = .spinning
+            lastTick = Date()
+            startTimerIfNeeded()
+        case .spinning:
+            targetVelocity = target
+            if target <= 0 {
+                phase = .coasting
+            }
+        case .coasting:
+            if target > 0 {
+                targetVelocity = target
+                phase = .spinning
+            }
+        case .blinking:
+            // The blink owns the image; the refresh after it (via onFinish)
+            // resumes spinning if the fans are still running.
+            break
+        }
+    }
+
+    /// Flashes the icon to signal a failed switch, then restores the state
+    /// that matches the live fan readings.
+    func flashFailure() {
+        guard !reduceMotion else { return }
+        phase = .blinking
+        blinkAccumulator = 0
+        blinkRemaining = 4 // two dim/bright cycles
+        lastTick = Date()
+        startTimerIfNeeded()
+    }
+
+    /// Stops immediately and asks the owner to restore the authoritative icon.
+    func stop() {
+        guard phase != .idle else { return }
+        phase = .idle
+        timer?.invalidate()
+        timer = nil
+        onFinish?()
+    }
+
+    private func startTimerIfNeeded() {
+        guard timer == nil else { return }
+        let timer = Timer(timeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    private func tick() {
+        guard let button else {
+            stop()
+            return
+        }
+        let now = Date()
+        // Clamp delayed frames so a busy run loop cannot cause a visible jump.
+        let delta = min(max(now.timeIntervalSince(lastTick), 0), 0.1)
+        lastTick = now
+
+        switch phase {
+        case .idle:
+            break
+        case .spinning:
+            if reduceMotion {
+                stop()
+                return
+            }
+            let smoothing = min(delta * velocitySmoothing, 1)
+            angularVelocity += (targetVelocity - angularVelocity) * smoothing
+            angle = (angle + angularVelocity * delta).truncatingRemainder(dividingBy: 360)
+            button.image = frame(at: angle, alpha: 1)
+        case .coasting:
+            angularVelocity = max(angularVelocity - spinDownDeceleration * delta, 0)
+            guard angularVelocity > 0 else {
+                stop()
+                return
+            }
+            angle = (angle + angularVelocity * delta).truncatingRemainder(dividingBy: 360)
+            button.image = frame(at: angle, alpha: 1)
+        case .blinking:
+            blinkAccumulator += delta
+            guard blinkAccumulator >= blinkInterval else { return }
+            blinkAccumulator = 0
+            blinkRemaining -= 1
+            guard blinkRemaining > 0 else {
+                stop()
+                return
+            }
+            let dimmed = blinkRemaining % 2 == 1
+            button.image = frame(at: 0, alpha: dimmed ? 0.3 : 1)
+        }
+    }
+
+    /// Real fan RPM is too fast to render directly without aliasing. Reuses
+    /// the perceptual scale from FanRotorView so the menu bar and the panel
+    /// rotor feel like the same machine.
+    private static func perceptualVelocity(forRPM rpm: Double) -> Double {
+        guard rpm > 1 else { return 0 }
+        return min(max(rpm / 5_000, 0.18), 1.15) * 360
+    }
+
+    /// Returns the un-rotated, full-opacity icon image — intended for the
+    /// static status bar item when the animator is idle. Shares the same
+    /// rendering path as the animated frames so the sizes are pixel-identical.
+    static func staticIcon(symbol: String) -> NSImage {
+        render(symbol: symbol, degrees: 0, alpha: 1)
+    }
+
+    // MARK: - Render
+
+    /// Returns a cached template frame for the quantized angle and alpha.
+    private func frame(at angle: Double, alpha: CGFloat) -> NSImage {
+        let quantized = (angle / frameQuantum).rounded() * frameQuantum
+        let key = "\(symbolName)-\(Int(quantized))-\(Int(alpha * 100))"
+        if let cached = frameCache[key] { return cached }
+        let rendered = Self.render(symbol: symbolName, degrees: quantized, alpha: alpha)
+        frameCache[key] = rendered
+        return rendered
+    }
+
+    private static func render(symbol: String, degrees: Double, alpha: CGFloat) -> NSImage {
+        let size = NSSize(width: 14, height: 14)
+        let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .medium)
+        let image = NSImage(size: size, flipped: false) { rect in
+            guard let base = NSImage(systemSymbolName: symbol, accessibilityDescription: "FanBar")?
+                .withSymbolConfiguration(config)
+            else { return false }
+            NSGraphicsContext.current?.imageInterpolation = .high
+            let transform = NSAffineTransform()
+            transform.translateX(by: rect.midX, yBy: rect.midY)
+            transform.rotate(byDegrees: degrees)
+            transform.translateX(by: -rect.midX, yBy: -rect.midY)
+            transform.concat()
+            base.draw(in: rect, from: .zero, operation: .sourceOver, fraction: alpha)
+            return true
+        }
+        image.isTemplate = true
+        return image
+    }
+}

--- a/Sources/FanBar/SettingsWindowPresenter.swift
+++ b/Sources/FanBar/SettingsWindowPresenter.swift
@@ -4,10 +4,14 @@ import SwiftUI
 
 /// Owns the settings window independently from the transient MenuBarExtra popover.
 @MainActor
-final class SettingsWindowPresenter {
+final class SettingsWindowPresenter: NSObject {
     static let shared = SettingsWindowPresenter()
 
     private var windowController: NSWindowController?
+    private let tabsItemIdentifier = NSToolbarItem.Identifier("fanbar.settings.tabs")
+    private weak var tabSegmentedControl: NSSegmentedControl?
+    private var lastSelectedTabRawValue = SettingsTab.menuBar.rawValue
+    private var defaultsObservation: NSObjectProtocol?
 
     @discardableResult
     func show(controller: FanController) -> NSWindow {
@@ -21,17 +25,18 @@ final class SettingsWindowPresenter {
                 rootView: FanBarSettingsView(controller: controller)
             )
             window = NSWindow(
-                contentRect: NSRect(x: 0, y: 0, width: 420, height: 330),
+                contentRect: NSRect(x: 0, y: 0, width: 460, height: 400),
                 styleMask: [.titled, .closable],
                 backing: .buffered,
                 defer: false
             )
             window.contentViewController = hostingController
+            installToolbar(on: window)
             // Keep added settings sections visible without coupling the window to a fixed height.
             hostingController.view.layoutSubtreeIfNeeded()
             let fittingSize = hostingController.view.fittingSize
             window.setContentSize(
-                NSSize(width: max(420, fittingSize.width), height: max(330, fittingSize.height))
+                NSSize(width: max(460, fittingSize.width), height: max(240, fittingSize.height))
             )
             window.isReleasedWhenClosed = false
             window.isRestorable = false
@@ -62,7 +67,91 @@ final class SettingsWindowPresenter {
     }
 
     func updateTitle() {
-        windowController?.window?.title = fanBarText("FanBar 设置", "FanBar Settings")
+        guard let window = windowController?.window else { return }
+        window.title = fanBarText("FanBar 设置", "FanBar Settings")
+        if let control = tabSegmentedControl {
+            for (index, tab) in SettingsTab.allCases.enumerated() where index < control.segmentCount {
+                control.setToolTip(tab.title, forSegment: index)
+            }
+        }
+    }
+
+    // MARK: - Toolbar
+
+    /// A native NSSegmentedControl floats in the toolbar area with no chrome
+    /// around it — no preference-style pill, just the control itself. Selection
+    /// writes to UserDefaults so SwiftUI swaps the visible content.
+    private func installToolbar(on window: NSWindow) {
+        let toolbar = NSToolbar(identifier: "fanbar.settings")
+        toolbar.delegate = self
+        toolbar.allowsUserCustomization = false
+        window.toolbar = toolbar
+        // Leave toolbarStyle at default — .preference would add a competing
+        // background tint and pull focus away from the segmented control.
+        lastSelectedTabRawValue = UserDefaults.standard.string(forKey: SettingsTab.preferenceKey)
+            ?? SettingsTab.menuBar.rawValue
+        defaultsObservation = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                // Covers external/preference-key writes that don't go through the toolbar.
+                self?.applySelectedTabChange()
+            }
+        }
+    }
+
+    /// Single path for tab changes: update the segmented control once, then resize
+    /// after SwiftUI has applied the new `@AppStorage` body on the next main turn.
+    /// Previously `syncTabSelection` and `resizeForCurrentTab` both gated on and
+    /// wrote `lastSelectedTabRawValue`, so resize always no-oped after sync.
+    private func applySelectedTabChange() {
+        let rawValue = UserDefaults.standard.string(forKey: SettingsTab.preferenceKey)
+            ?? SettingsTab.menuBar.rawValue
+        guard rawValue != lastSelectedTabRawValue else { return }
+        lastSelectedTabRawValue = rawValue
+
+        if let control = tabSegmentedControl,
+           let tab = SettingsTab(rawValue: rawValue),
+           let index = SettingsTab.allCases.firstIndex(of: tab),
+           control.selectedSegment != index {
+            control.selectedSegment = index
+        }
+
+        // Fitting size is only reliable after SwiftUI swaps tab content.
+        DispatchQueue.main.async { [weak self] in
+            self?.resizeWindowToFitContent()
+        }
+    }
+
+    @objc private func selectTabSegment(_ sender: NSSegmentedControl) {
+        guard SettingsTab.allCases.indices.contains(sender.selectedSegment) else { return }
+        let tab = SettingsTab.allCases[sender.selectedSegment]
+        UserDefaults.standard.set(tab.rawValue, forKey: SettingsTab.preferenceKey)
+        applySelectedTabChange()
+    }
+
+    private func resizeWindowToFitContent() {
+        guard let window = windowController?.window,
+              let contentView = window.contentView else { return }
+
+        contentView.layoutSubtreeIfNeeded()
+        let fittingSize = contentView.fittingSize
+        var newFrame = window.frameRect(
+            forContentRect: NSRect(
+                origin: .zero,
+                size: NSSize(
+                    width: max(460, fittingSize.width),
+                    height: max(240, fittingSize.height)
+                )
+            )
+        )
+        guard abs(newFrame.height - window.frame.height) > 1
+            || abs(newFrame.width - window.frame.width) > 1 else { return }
+        newFrame.origin.x = window.frame.minX
+        newFrame.origin.y = window.frame.maxY - newFrame.height
+        window.setFrame(newFrame, display: true, animate: true)
     }
 
     private func centerOnActiveScreen(_ window: NSWindow) {
@@ -79,5 +168,55 @@ final class SettingsWindowPresenter {
             y: visibleFrame.midY - window.frame.height / 2
         )
         window.setFrameOrigin(origin)
+    }
+}
+
+extension SettingsWindowPresenter: NSToolbarDelegate {
+    func toolbarDefaultItemIdentifiers(
+        _ toolbar: NSToolbar
+    ) -> [NSToolbarItem.Identifier] {
+        [.flexibleSpace, tabsItemIdentifier, .flexibleSpace]
+    }
+
+    func toolbarAllowedItemIdentifiers(
+        _ toolbar: NSToolbar
+    ) -> [NSToolbarItem.Identifier] {
+        toolbarDefaultItemIdentifiers(toolbar)
+    }
+
+    func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        guard itemIdentifier == tabsItemIdentifier else { return nil }
+        let control = NSSegmentedControl()
+        control.segmentCount = SettingsTab.allCases.count
+        control.trackingMode = .selectOne
+        // .automatic adopts the current macOS segmented-control style,
+        // which is intentionally quiet: only the selected segment gets
+        // a subtle highlight, the rest float against the toolbar.
+        control.segmentStyle = .automatic
+        let imageConfig = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
+        for (index, tab) in SettingsTab.allCases.enumerated() {
+            let image = NSImage(systemSymbolName: tab.symbol, accessibilityDescription: tab.title)?
+                .withSymbolConfiguration(imageConfig) ?? NSImage()
+            control.setImage(image, forSegment: index)
+            control.setToolTip(tab.title, forSegment: index)
+            control.setWidth(36, forSegment: index)
+        }
+        let savedTab = UserDefaults.standard.string(forKey: SettingsTab.preferenceKey)
+            .flatMap(SettingsTab.init(rawValue:)) ?? .menuBar
+        control.selectedSegment = SettingsTab.allCases.firstIndex(of: savedTab) ?? 0
+        control.target = self
+        control.action = #selector(selectTabSegment(_:))
+        control.sizeToFit()
+        tabSegmentedControl = control
+
+        let item = NSToolbarItem(itemIdentifier: itemIdentifier)
+        item.view = control
+        item.minSize = control.frame.size
+        item.maxSize = control.frame.size
+        return item
     }
 }

--- a/Sources/FanBar/SwitchFeedbackPreferences.swift
+++ b/Sources/FanBar/SwitchFeedbackPreferences.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Preference storage for the menu-bar fan activity animation (the icon
+/// spins while the fans run; a failed switch flashes it).
+enum SwitchFeedbackPreferences {
+    static let preferenceKey = "fanbar.switchFeedbackAnimationEnabled"
+
+    /// Enabled by default; only an explicit `false` turns the animation off.
+    static var isEnabled: Bool {
+        guard UserDefaults.standard.object(forKey: preferenceKey) != nil else { return true }
+        return UserDefaults.standard.bool(forKey: preferenceKey)
+    }
+}


### PR DESCRIPTION
## Summary
- Add RPM-driven menu-bar fan icon animation (spin + failure flash), with a user preference and reduce-motion support
- Redesign settings into a native toolbar tab control (Menu Bar / Cooling / General) and card layout
- Fix tab-driven window resize so switching panes no longer clips content; bump to 0.4.2

## Test plan
- [x] Open Settings; switch Menu Bar ↔ Cooling ↔ General and confirm window height animates and content is never clipped
- [x] Toggle “switch feedback” preference off; confirm icon stays static while fans run
- [x] Toggle preference on; confirm icon spins with RPM and flashes on a failed mode switch
- [x] Enable reduce-motion system setting; confirm continuous spin is suppressed
- [x] Silent wake / automatic restore paths do not flash failure feedback
- [x] Version shows 0.4.2 in settings footer / Info.plist