### PR TITLE
Publish bilingual GitHub release notes

### DIFF
--- a/.github/workflows/macos-release.yml
+++ b/.github/workflows/macos-release.yml
@@ -181,8 +181,16 @@ jobs:
       - name: Publish GitHub Release
         run: |
           release_files=(dist/FanBar-*.dmg dist/FanBar-*.dmg.sha256 dist/appcast.xml)
+          notes_file="docs/releases/${GITHUB_REF_NAME}.md"
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
             gh release upload "${GITHUB_REF_NAME}" "${release_files[@]}" --clobber
+            if [[ -f "${notes_file}" ]]; then
+              gh release edit "${GITHUB_REF_NAME}" --notes-file "${notes_file}"
+            fi
+          elif [[ -f "${notes_file}" ]]; then
+            gh release create "${GITHUB_REF_NAME}" "${release_files[@]}" \
+              --title "FanBar ${GITHUB_REF_NAME#v}" \
+              --notes-file "${notes_file}"
           else
             gh release create "${GITHUB_REF_NAME}" "${release_files[@]}" \
               --title "FanBar ${GITHUB_REF_NAME#v}" \

--- a/docs/releases/v0.4.3.md
+++ b/docs/releases/v0.4.3.md
@@ -1,0 +1,33 @@
+### 新增 / New
+
+- **可编辑智能温控曲线** — 设置页以散热曲线为第一路径：平滑曲线、可拖锚点、可选 CPU / GPU / SSD 温度来源，温度低于第一拐点时可 0% 停转
+  **Editable smart cooling curves** — Settings opens on Cooling first: a smooth curve, draggable anchors, CPU / GPU / SSD sources, and 0% idle below the first knee
+- **曲线与面板预设一一对应** — 静音 / 均衡 / 性能 / 极速各自保存一条曲线；菜单栏选择预设即套用对应曲线
+  **One curve per panel preset** — Silent, Balanced, Performance, and Extreme each store their own curve; choosing a preset in the menu applies that slot
+
+### 改进 / Improvements
+
+- **高级项默认折叠** — 锚点表、降温磁滞、每步限速放在「高级」里，主路径只保留曲线、预设和温度来源
+  **Advanced controls stay folded** — Anchor table, hysteresis, and per-step limits live under Advanced so the curve stays primary
+- **设置窗口适配屏幕** — 高度限制在可见屏幕内，内容可滚动，避免矮屏被裁切
+  **Settings window fits the display** — Height is clamped to the visible screen and tall content scrolls instead of clipping
+- **架构安装包** — 同时提供 Apple Silicon、Intel 与 Universal DMG；Sparkle 在线更新仍使用 Universal
+  **Architecture-specific installers** — Apple Silicon, Intel, and Universal DMGs; Sparkle updates still use the Universal image
+
+### 修复 / Fixes
+
+- **硬件写入失败不切换预设** — 只有 Helper 真正应用成功后才提交可见预设和曲线，避免界面声称已进入未生效的模式
+  **Failed hardware apply does not switch presets** — The visible preset and curve commit only after the helper write succeeds
+- **降温磁滞按输出保持** — 相同较低温度的连续采样会继续稳住转速，降温过程中不会把风扇往上调
+  **Falling hysteresis holds across equal samples** — Repeated cooler readings keep RPM; output never rises while cooling
+- **忽略过期 Helper 连接回调** — 旧 XPC 连接的 invalidation 不会清掉已经建好的新连接
+  **Stale helper invalidations are ignored** — An older connection cannot clear its replacement
+
+### 安装 / Install
+
+- Apple Silicon → `FanBar-0.4.3-arm64.dmg`
+- Intel → `FanBar-0.4.3-x86_64.dmg`
+- Universal → `FanBar-0.4.3.dmg`
+- 校验和见对应的 `.sha256` 文件 / SHA256 checksums in corresponding `.sha256` files
+
+**Full Changelog**: https://github.com/helson-lin/FanBar/compare/v0.4.2...v0.4.3

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -45,6 +45,11 @@ gh secret set APPLE_TEAM_ID
 
 ## 创建发布
 
+在打标签之前，把该版本的中英双语说明写到
+`docs/releases/vX.Y.Z.md`（与 `CFBundleShortVersionString` 一致）。本地发布
+脚本和 CI 会优先用这份文件作为 GitHub Release 正文；没有文件时才回退到
+`gh` 自动生成的英文提交列表。
+
 标签必须与 `App/Info.plist` 的版本完全一致。例如版本为 `0.3.0`：
 
 ```sh

--- a/scripts/release-local.sh
+++ b/scripts/release-local.sh
@@ -175,10 +175,14 @@ release_files=(
     "${x86_dmg}.sha256"
     "${appcast_path}"
 )
+notes_file="${project_root}/docs/releases/v${version}.md"
 if gh release view "${tag}" --repo "${repository}" >/dev/null 2>&1; then
     gh release upload "${tag}" "${release_files[@]}" \
         --repo "${repository}" \
         --clobber
+    if [[ -f "${notes_file}" ]]; then
+        gh release edit "${tag}" --repo "${repository}" --notes-file "${notes_file}"
+    fi
 else
     create_arguments=(
         "${tag}"
@@ -186,8 +190,12 @@ else
         --repo "${repository}"
         --verify-tag
         --title "FanBar ${version}"
-        --generate-notes
     )
+    if [[ -f "${notes_file}" ]]; then
+        create_arguments+=(--notes-file "${notes_file}")
+    else
+        create_arguments+=(--generate-notes)
+    fi
     if (( draft )); then create_arguments+=(--draft); fi
     gh release create "${create_arguments[@]}"
 fi


### PR DESCRIPTION
## Summary
- Add `docs/releases/v0.4.3.md` with Chinese and English release copy in the 0.4.2 style
- Prefer that file in `release-local.sh` and the CI publisher instead of English-only `--generate-notes`
- The live v0.4.3 GitHub Release is already updated from the same notes

## Test plan
- [x] Open https://github.com/helson-lin/FanBar/releases/tag/v0.4.3 and confirm 新增 / 改进 / 修复 / 安装 are bilingual
- [x] Confirm `docs/releases/v0.4.3.md` matches the published Release body
- [x] Next local/CI release uses the notes file when `docs/releases/vX.Y.Z.md` exists