### PR TITLE
Fix helper SIGTRAP crash in signal handler closures

### DIFF
--- a/Sources/FanBarHelper/FanBarHelperMain.swift
+++ b/Sources/FanBarHelper/FanBarHelperMain.swift
@@ -12,7 +12,11 @@ enum FanBarHelperMain {
         let term = DispatchSource.makeSignalSource(signal: SIGTERM)
         let interrupt = DispatchSource.makeSignalSource(signal: SIGINT)
         for source in [term, interrupt] {
-            source.setEventHandler {
+            // Explicitly @Sendable keeps this closure nonisolated. Without it,
+            // Swift concurrency infers an isolated closure whose executor
+            // assertion traps (SIGTRAP) when libdispatch runs the handler on
+            // the global concurrent queue, skipping restoreForShutdown().
+            source.setEventHandler { @Sendable in
                 service.restoreForShutdown()
                 exit(EXIT_SUCCESS)
             }


### PR DESCRIPTION
## 问题

`FanBarHelper`（root 守护进程）在收到 SIGTERM/SIGINT（关机、休眠、helper 重装、App 退出）时周期性崩溃，崩溃点集中在信号处理闭包，导致无法在退出路径上恢复风扇自动控制。

崩溃报告（3 份 `.ips`）均为 `EXC_BREAKPOINT / SIGTRAP`：

```
_dispatch_assert_queue_fail
dispatch_assert_queue$V2.cold.1
_swift_task_checkIsolatedSwift
closure #1 in static FanBarHelperMain.main()
_dispatch_source_latch_and_call
```

## 根因

DispatchSource 信号事件处理闭包未显式标记 `@Sendable`，被 Swift 并发推断为隔离闭包。libdispatch 将 handler 派发到 `com.apple.root.default-qos.overcommit` 全局并发队列执行时，executor 断言失败直接触发 SIGTRAP，进程在执行 `restoreForShutdown()` 之前即终止。

## 修复

给 `setEventHandler` 闭包加上显式 `@Sendable`，使其保持 nonisolated，消除 executor 断言（Sources/FanBarHelper/FanBarHelperMain.swift:15）。

## 验证

- 修复前：运行 helper 并发送 SIGTERM → 退出码 133（SIGTRAP），复现线上崩溃
- 修复后：SIGTERM / SIGINT 均正常执行 `restoreForShutdown()` 并以退出码 0 退出
- `swift test`：20 个测试全部通过

## 附注

崩溃日志中另有一例 SIGKILL（Launch Constraint Violation），为崩溃后 launchd 重拉时开发签名（无 teamID）触发，与本次修复无关，正式签名构建不受影响。